### PR TITLE
Update to 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Imbalance-Xgboost
 This software includes the codes of Weighted Loss and Focal Loss [1] implementations for Xgboost [2](<\url> https://github.com/dmlc/xgboost) in binary classification problems. The principal reason for us to use Weighted and Focal Loss functions is to address the problem of label-imbalanced data. The original Xgboost program provides a convinient way to customize the loss function, but one will be needing to compute the first and second order derivatives to implement them. The major contribution of the software is the drivation of the gradients and the implementations of them. <br/>
 
-## Software Release
-**The project has been posted on github for several months, and now a correponding API on Pypi is released. Special thanks to @icegrid and @shaojunchao for help correct errors in the previous versions. The codes are now updated to version 0.7 and it now allows users to specify the weighted parameter \alpha and focal parameter \gamma outside the script. Also it supports higher version of XGBoost now.** <br />
+<!-- ## Software Update
+**The project has been posted on github for several months, and now a correponding API on Pypi is released. Special thanks to @icegrid and @shaojunchao for help correct errors in the previous versions. The codes are now updated to version 0.7 and it now allows users to specify the weighted parameter \alpha and focal parameter \gamma outside the script. Also it supports higher version of XGBoost now.** <br /> -->
+
+## Software Update
+**Version 0.8.1: The package now supports early stopping, you can specify this by `early_stopping_rounds` when initializing the object.**
 
 ## Version Notification
-**From version 0.7.0 on Imbalance-XGBoost starts to support higher versions of XGBoost and removes supports of versions earlier than 0.4a30(XGBoost>=0.4a30). This contradicts with the previous requirement of XGBoost<=0.4a30. Please choose the version fits your system accordingly.**
+**From version 0.7.0 on Imbalance-XGBoost starts to support higher versions of XGBoost and removes supports of versions earlier than 0.4a30(XGBoost>=0.4a30). This contradicts with the previous requirement of XGBoost<=0.4a30. Please choose the version that fits your system accordingly.** <br />
+**Starting from version 0.8.1, the package now requires xgboost to have a newer version of >=1.1.1. This is due to some changes on deprecated arguments of the XGBoost.**
 
 ## Installation
-Installing with Pypi will be easiest way, you can run: <br />
+Installing with Pypi is the easiest way, you can run: <br />
 
 ```
 pip install imbalance-xgboost
 ```
-If you have multiple versions of Python, make sure you're using Python 3 (run with `pip3 install imbalance-xgboost`). Currently, the program only supports Python 3.5 and 3.6. <br />
+If you have multiple versions of Python, make sure you're using Python 3 (run with `pip3 install imbalance-xgboost`). The program are designated for Python 3.5 and 3.6. That being said, an (incomplete) test does not find any compatible issue on Python 3.7 and 3.8. <br />
 
 The package has hard depedency on numpy, sklearn and xgboost. <br />
 
@@ -150,7 +154,7 @@ If you use this package in your research please cite our paper: <br />
 ```
 **More information on the software**: <br />
 @author: Chen Wang, Dept. of Computer Science, School of Art and Science, Rutgers University (previously affiliated with University College London, Sichuan University and Northwestern Polytechnical University) <br/>
-@version: 0.7.4
+@version: 0.8.1
 
 ## References
 [1] Lin, Tsung-Yi, Priyal Goyal, Ross Girshick, Kaiming He, and Piotr Dollár. "Focal loss for dense object detection." IEEE transactions on pattern analysis and machine intelligence (2018). <br/>

--- a/imxgboost/imbalance_xgb.py
+++ b/imxgboost/imbalance_xgb.py
@@ -35,7 +35,7 @@ class imbalance_xgboost(BaseEstimator, ClassifierMixin):
        This wrapper would provide a Xgboost interface with sklearn estimiator structure, which could be stacked in other Sk pipelines
     """
 
-    def __init__(self, num_round=10, max_depth=10, eta=0.3, silent_mode=True, objective_func='binary:logitraw',
+    def __init__(self, num_round=10, max_depth=10, eta=0.3, verbosity=1, objective_func='binary:logitraw',
                  eval_metric='logloss', booster='gbtree', special_objective=None, imbalance_alpha=None,
                  focal_gamma=None):
         """
@@ -44,7 +44,7 @@ class imbalance_xgboost(BaseEstimator, ClassifierMixin):
         :param max_depth. The maximum depth of the classification boosting, need to be specified
         :param num_class. The number of classes for the classifier
         :param eta Step. Size shrinkage used in update to prevents overfitting
-        :param silent_mode. Set to 'True' or 'False' to determine if print the information during training. True is higly recommended
+        :param verbosity. Set to '1' or '0' to determine if print the information during training. True is higly recommended
         :param objective_func. The objective function we would like to optimize
         :param eval_metric. The loss metrix. Note this is partially correlated to the objective function, and unfit loss function would lead to problematic loss
         :param booster. The booster to be usde, can be 'gbtree', 'gblinear' or 'dart'.
@@ -54,7 +54,7 @@ class imbalance_xgboost(BaseEstimator, ClassifierMixin):
         self.num_round = num_round
         self.max_depth = max_depth
         self.eta = eta
-        self.silent_mode = silent_mode
+        self.verbosity = verbosity
         self.objective_func = objective_func
         self.eval_metric = eval_metric
         self.booster = booster
@@ -69,7 +69,7 @@ class imbalance_xgboost(BaseEstimator, ClassifierMixin):
             # get the parameter list
             self.para_dict = {'max_depth': self.max_depth,
                               'eta': self.eta,
-                              'silent': self.silent_mode,
+                              'verbosity': self.verbosity,
                               'objective': self.objective_func,
                               'eval_metric': self.eval_metric,
                               'booster': self.booster}
@@ -77,7 +77,7 @@ class imbalance_xgboost(BaseEstimator, ClassifierMixin):
             # get the parameter list, without stating the objective function
             self.para_dict = {'max_depth': self.max_depth,
                               'eta': self.eta,
-                              'silent': self.silent_mode,
+                              'verbosity': self.verbosity,
                               'eval_metric': self.eval_metric,
                               'booster': self.booster}
         # make sure data is in [nData * nSample] format

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="imbalance-xgboost",
-    version="0.7.4",
+    version="0.8.0",
     author="Chen Wang",
     author_email="chen.wang.cs@rutgers.edu",
     description="XGBoost for label-imbalanced data: XGBoost with weighted and focal loss functions",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="imbalance-xgboost",
-    version="0.8.0",
+    version="0.8.1",
     author="Chen Wang",
     author_email="chen.wang.cs@rutgers.edu",
     description="XGBoost for label-imbalanced data: XGBoost with weighted and focal loss functions",


### PR DESCRIPTION
Changes:
The deprecated argument `silent' is removed to resolve a warning issue. Accordingly, the package now requires the xgboost version to be newer than 1.1.1 (mid-2020).
You can now specify early stopping rounds when initializing the object.